### PR TITLE
README: fix travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 F.D.G.L Web Site
 ================
-[![Build Status](https://travis-ci.com/F-D-G-L/fdgl-homepage.svg?branch=main)](https://travis-ci.com/F-D-G-L/fdgl-homepage)
+[![Build Status](https://travis-ci.org/F-D-G-L/fdgl-homepage.svg?branch=main)](https://travis-ci.org/F-D-G-L/fdgl-homepage)
 [![codecov](https://codecov.io/gh/F-D-G-L/fdgl-homepage/branch/main/graph/badge.svg?token=C9LXJG7T4Y)](https://codecov.io/gh/F-D-G-L/fdgl-homepage)


### PR DESCRIPTION
I used the wrong URL in the travis badge, fix it.

Signed-off-by: Johannes Thumshirn <jth@kernel.org>